### PR TITLE
rewording suggestions

### DIFF
--- a/pep-0678.rst
+++ b/pep-0678.rst
@@ -15,9 +15,9 @@ Abstract
 ========
 Exception objects are typically initialized with a message that describes the
 error which has occurred.  Because further information may be available when the
-exception is caught and re-raised, this PEP proposes to add a ``.__note__``
-attribute and update the builtin traceback formatting code to include it in
-the formatted traceback following the exception string.
+exception is caught and re-raised, or included in an ``ExceptionGroup`` , this PEP
+proposes to add a ``.__note__`` attribute and update the builtin traceback formatting
+code to include it in the formatted traceback following the exception string.
 
 This is particularly useful in relation to :pep:`654` ``ExceptionGroup`` s, which
 make previous workarounds ineffective or confusing.  Use cases have been identified
@@ -34,7 +34,7 @@ For example,
 - testing libraries may wish to show the values involved in a failing assertion,
   or the steps to reproduce a failure (e.g. ``pytest`` and ``hypothesis`` ; example below).
 - code with retries may wish to note which iteration or timestamp raised which
-  error - especially if re-raising them in an ``ExceptionGroup``
+  of several possible errors - especially if re-raising them in an ``ExceptionGroup``
 - programming environments for novices can provide more detailed descriptions
   of various errors, and tips for resolving them (e.g. ``friendly-traceback`` ).
 
@@ -104,6 +104,19 @@ exception includes a note of the minimal failing example::
         |     x=0,
         | )
         +------------------------------------
+
+
+Non-goals
+---------
+``__note__`` is *not* intended to carry structured data.  If your note is for use by
+a program rather than display to a human, we recommend instead chosing a convention
+for an attribute like e.g. ``err._parse_errors = ...`` on the error or ``ExceptionGroup``
+(`discussion <https://discuss.python.org/t/accepting-pep-654-exception-groups-and-except/10813/26>`__,
+`discussion <https://bugs.python.org/issue46431>`__).
+
+As a rule of thumb, prefer `exception chaining <https://docs.python.org/3/tutorial/errors.html#exception-chaining>`__
+when the error is going to be re-raised or handled as an individual error; and prefer
+``__note__`` when you are collecting multiple exception objects to handle together or later.
 
 
 Specification
@@ -215,6 +228,9 @@ exception chaining, and are unnecessary with ``BaseException.__note__`` :
     Explanation:                                                            # Hence this PEP!
     You can reproduce this error by ...
 
+**Where these factors are not problematic, we encourage use of exception chaining
+rather than** ``__note__`` .
+
 
 Subclass Exception and add ``__note__`` downstream
 --------------------------------------------------
@@ -227,6 +243,49 @@ implement this once, upstream.
 Custom exception types could implement their ``__str__`` method to include our
 proposed ``__note__`` semantics, but this would be rarely and inconsistently
 applicable.
+
+
+Augment the ``raise`` statement
+-------------------------------
+One discussion proposed ``raise Exception() with "note contents"`` , but this
+does not address the original motivation of compatibility with ``ExceptionGroup`` .
+
+Furthermore, this would be an additional feature over adding the attribute and
+modifying the traceback-formatting code, and we do not expect ``__note__`` to be
+so frequently-used as to justify new syntax or even a new ``.with_note()`` method
+(analogous to ``.with_traceback()`` ).
+
+
+Allow any object, and cast to string for display
+------------------------------------------------
+We have not identified any scenario where libraries would want to do anything but either
+concatenate or replace notes, and so the additional complexity and interoperability
+challenges do not seem justified.
+
+Variations on this have also been proposed for forward-compatibility with a future
+structured API, but in the absence of any proposed use-case (see also "Non-goals")
+we strongly prefer to keep things simple - and note that implementing any nontrival
+future behavior would then break backwards-compatibility.
+
+
+Add a helper function ``contexlib.add_exc_note()``
+--------------------------------------------------
+We don't expect notes to be used frequently enough to justify this either, but
+provide the following extensible recipe::
+
+    @contextlib.contextmanager
+    def add_exc_note(note: str):
+        try:
+            yield
+        except Exception as err:
+            if err.__note__ is None:
+                err.__note__ = note
+            else:
+                err.__note__ = err.__note__ + "\n\n" + note
+            raise
+
+    with add_exc_note(f"While attempting to frobnicate {item=}"):
+        frobnicate_or_raise(item)
 
 
 Store notes in ``ExceptionGroup`` s

--- a/pep-0678.rst
+++ b/pep-0678.rst
@@ -251,27 +251,27 @@ One discussion proposed ``raise Exception() with "note contents"`` , but this
 does not address the original motivation of compatibility with ``ExceptionGroup`` .
 
 Furthermore, this would be an additional feature over adding the attribute and
-modifying the traceback-formatting code, and we do not expect ``__note__`` to be
-so frequently-used as to justify new syntax or even a new ``.with_note()`` method
-(analogous to ``.with_traceback()`` ).
+modifying the traceback-formatting code, and we do not believe that the added
+complexity of new language syntax is justified for the problem we are solving
+here.
 
 
 Allow any object, and cast to string for display
 ------------------------------------------------
 We have not identified any scenario where libraries would want to do anything but either
 concatenate or replace notes, and so the additional complexity and interoperability
-challenges do not seem justified.
+challenges do not seem justified at this time.
 
 Variations on this have also been proposed for forward-compatibility with a future
 structured API, but in the absence of any proposed use-case (see also "Non-goals")
-we strongly prefer to keep things simple - and note that implementing any nontrival
-future behavior would then break backwards-compatibility.
+we prefer to implement a restrictive API that can be relaxed in the future rather a
+very flexible API that will be hard to change.
 
 
 Add a helper function ``contexlib.add_exc_note()``
 --------------------------------------------------
-We don't expect notes to be used frequently enough to justify this either, but
-provide the following extensible recipe::
+
+It was suggested to add the following utility to the standard library::
 
     @contextlib.contextmanager
     def add_exc_note(note: str):
@@ -286,6 +286,9 @@ provide the following extensible recipe::
 
     with add_exc_note(f"While attempting to frobnicate {item=}"):
         frobnicate_or_raise(item)
+
+We don't believe this needs to be discussed as part of the current PEP, because
+it can be added in the future if there is concensus that it is useful in practice.
 
 
 Store notes in ``ExceptionGroup`` s


### PR DESCRIPTION


I made a couple of suggestions - as I said, I don't think we should try to sell this by saying "It won't be used much" (they why bother with the PEP?).

Better to say "we don't know how it will be used so let's go easy on the syntactic sugar and over-engineering and remain open for changes as we learn more about how this feature is used".


<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->
